### PR TITLE
Add all fields in Food serializer and add filterset fields to viewset

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -25,4 +25,5 @@ router.register(r'food', views.FoodView, 'food')
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include(router.urls)),
+    path('api/metric-options/', views.metric_options, name='metric-options'),
 ]

--- a/backend/freshtrack/serializers.py
+++ b/backend/freshtrack/serializers.py
@@ -3,10 +3,66 @@ from .models import Food
 
 
 class FoodSerializer(serializers.ModelSerializer):
+    category_name = serializers.CharField(source='category.name')
+    pantry_metric = serializers.SerializerMethodField()
+    pantry_after_opening_metric = serializers.SerializerMethodField()
+    refrigerate_metric = serializers.SerializerMethodField()
+    refrigerate_after_opening_metric = serializers.SerializerMethodField()
+    refrigerate_after_thawing_metric = serializers.SerializerMethodField()
+    freezer_metric = serializers.SerializerMethodField()
+
     class Meta:
         model = Food
-        # TODO: fix enum field JSON issue
         fields = (
             'name',
             'keywords',
+            'external_id',
+            'category_name',
+            'pantry_min',
+            'pantry_max',
+            'pantry_metric',
+            'pantry_tips',
+            'pantry_after_opening_min',
+            'pantry_after_opening_max',
+            'pantry_after_opening_metric',
+            'refrigerate_min',
+            'refrigerate_max',
+            'refrigerate_metric',
+            'refrigerate_tips',
+            'refrigerate_after_opening_min',
+            'refrigerate_after_opening_max',
+            'refrigerate_after_opening_metric',
+            'refrigerate_after_thawing_min',
+            'refrigerate_after_thawing_max',
+            'refrigerate_after_thawing_metric',
+            'freezer_min',
+            'freezer_max',
+            'freezer_tips',
+            'freezer_metric',
+            'expired',
+            'consumed',
+            'created_at',
+            'deleted_at',
         )
+    
+    # TODO: create a mixin to handle enum fields
+    def get_pantry_metric(self, obj):
+        return self.format_metric(obj.pantry_metric)
+
+    def get_pantry_after_opening_metric(self, obj):
+        return self.format_metric(obj.pantry_after_opening_metric)
+
+    def get_refrigerate_metric(self, obj):
+        return self.format_metric(obj.refrigerate_metric)
+
+    def get_refrigerate_after_opening_metric(self, obj):
+        return self.format_metric(obj.refrigerate_after_thawing_metric)
+
+    def get_refrigerate_after_thawing_metric(self, obj):
+        return self.format_metric(obj.refrigerate_after_thawing_metric)
+
+    def get_freezer_metric(self, obj):
+        return self.format_metric(obj.freezer_metric)
+
+    def format_metric(self, metric):
+        return metric.value if metric else None

--- a/backend/freshtrack/views.py
+++ b/backend/freshtrack/views.py
@@ -1,10 +1,19 @@
 from django.shortcuts import render
+from django.http import JsonResponse
 from rest_framework import viewsets
+
 from .serializers import FoodSerializer
 from .models import Food
+from .enums import Metric
 
 
 class FoodView(viewsets.ModelViewSet):
     serializer_class = FoodSerializer
     queryset = Food.objects.all()
     filterset_fields = ['name', 'keywords']
+
+
+def metric_options(request):
+    options = [option.value for option in Metric]
+
+    return JsonResponse({'metric_options': options})

--- a/backend/freshtrack/views.py
+++ b/backend/freshtrack/views.py
@@ -7,3 +7,4 @@ from .models import Food
 class FoodView(viewsets.ModelViewSet):
     serializer_class = FoodSerializer
     queryset = Food.objects.all()
+    filterset_fields = ['name', 'keywords']


### PR DESCRIPTION
- Finalize serializer to include all fields on `Food` model.
- Add new endpoint to list all options available for the "Metric" field, so that the frontend can display this as a dropdown menu option for metric-related fields.
- Add `filterset_fields` to the Food viewset so that the user can search for Food using the name or keyword.
